### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,35 +68,13 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
       "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
     },
-    "axios": {
-      "version": "0.15.3",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.15.3.tgz",
-      "integrity": "sha1-LJ1jiy4ZGgjqHWzJiOrda6W9wFM=",
-      "requires": {
-        "follow-redirects": "1.0.0"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
     "cap": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/cap/-/cap-0.2.0.tgz",
-      "integrity": "sha512-mc2MOjNCeLsXS1zrzcH20vVVfeFmXflGKT2cqdHF1CUXhwjmC1RNgCE5IxN/5qlawylpO7m+0kJL17YzOTQWYw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cap/-/cap-0.2.1.tgz",
+      "integrity": "sha512-0n10YndTkI4V+rsPVvYFdqlA0Bjf8NFlP/Wgp0W0ymudkijuqkmSVdIWigFe2YdPhjjxTJdW9Mu5ee4VwB0L+A==",
       "requires": {
-        "nan": "^2.8.0"
+        "nan": "^2.14.0"
       }
-    },
-    "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -111,14 +89,6 @@
         "which": "^1.2.9"
       }
     },
-    "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
     "default-gateway": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
@@ -128,11 +98,6 @@
         "execa": "^0.10.0",
         "ip-regex": "^2.1.0"
       }
-    },
-    "easy-fit": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/easy-fit/-/easy-fit-0.0.6.tgz",
-      "integrity": "sha1-+gX0UGBfNILRKuZZ0x3K/YCdp5g="
     },
     "execa": {
       "version": "0.10.0",
@@ -147,14 +112,6 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/follow-redirects/-/follow-redirects-1.0.0.tgz",
-      "integrity": "sha1-jjQpjL0uF28lTv/sdaHHjMhJ/Tc=",
-      "requires": {
-        "debug": "^2.2.0"
       }
     },
     "get-stream": {
@@ -202,15 +159,10 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "nice-try": {
       "version": "1.0.4",
@@ -259,16 +211,6 @@
         "long": "^4.0.0"
       }
     },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -309,18 +251,6 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
-      }
-    },
-    "zwift-mobile-api": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/zwift-mobile-api/-/zwift-mobile-api-0.2.6.tgz",
-      "integrity": "sha1-0AxkIoiPKWAwAUSQV2OaJSOSedU=",
-      "requires": {
-        "axios": "^0.15.3",
-        "babel-runtime": "^6.11.6",
-        "easy-fit": "0.0.6",
-        "protobufjs": "^6.6.0",
-        "qs": "^6.3.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,8 @@
   },
   "homepage": "https://github.com/jeroni7100/zwift-packet-monitor#readme",
   "dependencies": {
-    "cap": "^0.2.0",
-    "protobufjs": "^6.8.8",
-    "zwift-mobile-api": "^0.2.5"
+    "cap": "^0.2.1",
+    "protobufjs": "^6.8.8"
   },
   "devDependencies": {
     "internal-ip": "^3.0.1"


### PR DESCRIPTION
Hi,

I updated the dependencies:

1. I use your fork because you do not rely on zwift-mobile-api. Unfortunately it is still a npm-dependency although not used any more. So I remove it.
1. I had to update cap to 0.2.1 because using node v13.8.0 cap 0.2.0 did not compile any more (in Linux). Using this version everything works fine - tested on Linux and MacOS.

If this pull request is OK to you and you merged it, could you please build a new npm version 0.3.4 of your package so I can use it as an depdency in my project?

Thx,
RasPelikan