### PR TITLE
Fix for linux users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 node_modules/
+debug.js


### PR DESCRIPTION
Couldn't get Cap to open devices properly on Linux (ubuntu 20.04)
By letting it find a device on its own it worked.

You may want to handle it in a cleaner way then my tre/catch/if/else block.